### PR TITLE
Enable restriction by region, allow restriction without stage name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: node_js
+node_js: 'node' # Latest stable Node.js release
+cache:
+  directories:
+    - node_modules # Our node modules
+    - $HOME/.npm # Globally installed packages, e.g. NPM
+
+branches: # Skip tag builds
+  except:
+    - /^\d+.\d+.\d+$/
+
+install:
+  - npm install
+  - npm update # Ensure to use latest versions of dependencies
+
+stages:
+  - name: test
+    if: type = pull_request AND branch != master
+  - name: deploy
+    if: branch = master AND type != pull_request
+
+jobs:
+  include:
+    - stage: test
+      script: npm run lint && npm run prettier && npm test
+    - stage: deploy
+      script: skip
+      deploy:
+        provider: npm
+        email: tech@maas.global
+        api_key: $NPM_TOKEN
+      after_deploy: ./scripts/tag.sh

--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ In the example, dev and, e.g. sandbox stages are allowed to deploy to account id
 This plugin is triggered before deployment, but if you want manually to test if your current credentials can deploy to a particular stage, you can run the following command.
 
 ```shell
-sls validate --stage dev
+sls validate --stage dev --region eu-west-1
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,36 @@ npm i serverless-deployment-manager --save-dev
 
 ## Example usage
 
+1. Account id only
+
+```yaml
+# serverless.yml
+
+plugins:
+  - serverless-deployment-manager
+
+custom:
+  deployment:
+    - accountId: '0123456789'
+```
+
+or multiple accounts
+
+```yaml
+# serverless.yml
+
+plugins:
+  - serverless-deployment-manager
+
+custom:
+  deployment:
+    - accountIds:
+        - '0123456789'
+        - '1234567890'
+```
+
+2. Stage only
+
 ```yaml
 # serverless.yml
 
@@ -21,13 +51,65 @@ plugins:
 custom:
   deployment:
     - stage: dev
-      accountId: '0123456789'
+    - stage: /box$/ # regexp
+    - stage: test
+    - stage: prod
+```
+
+3. Region only
+
+```yaml
+# serverless.yml
+
+plugins:
+  - serverless-deployment-manager
+
+custom:
+  deployment:
+    - region: 'eu-west-1'
+```
+
+or multiple regions
+
+```yaml
+# serverless.yml
+
+plugins:
+  - serverless-deployment-manager
+
+custom:
+  deployment:
+    - regions:
+        - 'eu-north-1'
+        - 'eu-west-1'
+```
+
+4. Stage, region, and account id
+
+```yaml
+# serverless.yml
+
+plugins:
+  - serverless-deployment-manager
+
+custom:
+  deployment:
+    - stage: dev
+      accountIds:
+        - '0123456789'
+        - '3456789012'
+      regions:
+        - eu-north-1
+        - eu-west-1
     - stage: /box$/ # regexp
       accountId: '0123456789'
+      region: eu-north-1
     - stage: test
       accountId: '1234567890'
+      region: eu-north-1
     - stage: prod
       accountId: '2345678901'
+      region: eu-north-1
 ```
 
 In the example, dev and, e.g. sandbox stages are allowed to deploy to account id '0123456789', test to '1234567890', and production stage to account id '2345678901'.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-deployment-manager",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Serverless Framework Plugin for managing deployment to predefined AWS accounts",
   "main": "lib/index.js",
   "scripts": {

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# if master branch and not a pull request
+if [ $TRAVIS_BRANCH == 'master' ] && [ -z $TRAVIS_PULL_REQUEST_BRANCH ]
+then
+  latest=$(npm info serverless-deployment-manager dist-tags.latest)
+  git tag v${latest}
+  git push https://maasglobal:$GITHUB_API_TOKEN@github.com/maasglobal/serverless-deployment-manager v${latest}
+else
+  echo "Package is tagged only from master branch"
+fi

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,23 @@
 'use strict';
 
 const AWS = require('aws-sdk');
+const { filter, isNil, pipe, head, sortBy } = require('ramda');
+
+function stageType(stage) {
+  if (/^\/.*\/(i|g|m|s|u|y)*$/.test(stage)) {
+    return 1;
+  } else if (isNil(stage)) {
+    return 2;
+  }
+  return 0;
+}
 
 function testStage(stage, deploymentDefinitionStage) {
+  if (isNil(deploymentDefinitionStage)) {
+    return true;
+  }
   let regexp;
-  if (/^\/.*\/(i|g|m|s|u|y)*$/.test(deploymentDefinitionStage)) {
+  if (stageType(deploymentDefinitionStage) === 1) {
     const pattern = deploymentDefinitionStage.substr(1, deploymentDefinitionStage.lastIndexOf('/') - 1);
     const flag = deploymentDefinitionStage.substr(deploymentDefinitionStage.lastIndexOf('/') + 1);
     regexp = new RegExp(pattern, flag);
@@ -44,27 +57,20 @@ class DeploymentManagerPlugin {
       throw new Error('[serverless-deployment-guard] service.custom.deployment definition is missing');
     }
 
-    const deploymentDefinitions = service.custom.deployment.filter(({ stage }) =>
-      testStage(processedInput.options.stage, stage)
-    );
+    const deploymentDefinition = pipe(
+      filter(({ stage }) => testStage(processedInput.options.stage, stage)),
+      sortBy(({ stage }) => stageType(stage)),
+      head
+    )(service.custom.deployment);
 
-    if (deploymentDefinitions.length === 0) {
+    if (isNil(deploymentDefinition)) {
       throw new Error(`[serverless-deployment-guard] stage '${processedInput.options.stage}' cannot be deployed`);
     }
 
-    if (deploymentDefinitions.every(item => !!item.accountId)) {
+    if (!isNil(deploymentDefinition.accountId)) {
       const sts = new AWS.STS({ region: processedInput.options.region });
       const { Account } = await sts.getCallerIdentity().promise();
-
-      const exists = !!service.custom.deployment.find(item => {
-        return (
-          item.stage &&
-          item.accountId &&
-          testStage(processedInput.options.stage, item.stage) &&
-          item.accountId.toString() === Account
-        );
-      });
-      if (!exists) {
+      if (deploymentDefinition.accountId !== Account) {
         throw new Error(
           `[serverless-deployment-guard] stage '${processedInput.options.stage}' cannot be deployed to account '${Account}'`
         );

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,10 +36,10 @@ afterAll(() => {
 describe('#authorizer handler', () => {
   it('should pass if stage and account is correct', async () => {
     const deploymentManager = new DeploymentGuardPlugin({
-      processedInput: { options: { stage: 'dev' } },
+      processedInput: { options: { stage: 'dev', region: 'eu-north-1' } },
       service: {
         custom: {
-          deployment: [{ stage: 'dev', accountId: '0123456789' }],
+          deployment: [{ stage: 'dev', accountId: '0123456789', region: 'eu-north-1' }],
         },
       },
     });
@@ -73,6 +73,34 @@ describe('#authorizer handler', () => {
     await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
   });
 
+  it('should pass if region is correct', async () => {
+    const deploymentManager = new DeploymentGuardPlugin({
+      processedInput: { options: { stage: 'dev', region: 'eu-north-1' } },
+      service: {
+        custom: {
+          deployment: [{ region: 'eu-north-1' }],
+        },
+      },
+    });
+
+    await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
+  });
+
+  it('should fail if region is incorrect', async () => {
+    const deploymentManager = new DeploymentGuardPlugin({
+      processedInput: { options: { stage: 'dev', region: 'us-east-1' } },
+      service: {
+        custom: {
+          deployment: [{ region: 'eu-north-1' }],
+        },
+      },
+    });
+
+    await expect(deploymentManager.validateStageAndAccount()).rejects.toThrow({
+      message: "[serverless-deployment-guard] stage 'dev' cannot be deployed to region 'us-east-1'",
+    });
+  });
+
   it('should pass if regexp stage with flags and account is correct', async () => {
     const deploymentManager = new DeploymentGuardPlugin({
       processedInput: { options: { stage: 'SANDBOX' } },
@@ -86,19 +114,31 @@ describe('#authorizer handler', () => {
     await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
   });
 
-  // TODO: later
-  // it('should pass if stage and account is correct in one of the definitions', async () => {
-  //   const deploymentManager = new DeploymentGuardPlugin({
-  //     processedInput: { options: { stage: 'dev' } },
-  //     service: {
-  //       custom: {
-  //         deployment: [{ stage: 'dev', accountId: '1234567890' }, { stage: 'dev', accountId: '0123456789' }],
-  //       },
-  //     },
-  //   });
+  it('should pass if stage and account is correct in one of the definitions', async () => {
+    const deploymentManager = new DeploymentGuardPlugin({
+      processedInput: { options: { stage: 'dev' } },
+      service: {
+        custom: {
+          deployment: [{ stage: 'dev', accountId: '1234567890' }, { stage: 'dev', accountId: '0123456789' }],
+        },
+      },
+    });
 
-  //   await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
-  // });
+    await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
+  });
+
+  it('should pass if stage and account is correct in account ids array', async () => {
+    const deploymentManager = new DeploymentGuardPlugin({
+      processedInput: { options: { stage: 'dev' } },
+      service: {
+        custom: {
+          deployment: [{ stage: 'dev', accountIds: ['1234567890', '0123456789'] }],
+        },
+      },
+    });
+
+    await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
+  });
 
   it('should pass if stage is correct and no account id is defined', async () => {
     const deploymentManager = new DeploymentGuardPlugin({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,6 +60,19 @@ describe('#authorizer handler', () => {
     await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
   });
 
+  it('should pass if account is correct', async () => {
+    const deploymentManager = new DeploymentGuardPlugin({
+      processedInput: { options: { stage: 'dev' } },
+      service: {
+        custom: {
+          deployment: [{ accountId: '0123456789' }],
+        },
+      },
+    });
+
+    await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
+  });
+
   it('should pass if regexp stage with flags and account is correct', async () => {
     const deploymentManager = new DeploymentGuardPlugin({
       processedInput: { options: { stage: 'SANDBOX' } },
@@ -73,18 +86,19 @@ describe('#authorizer handler', () => {
     await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
   });
 
-  it('should pass if stage and account is correct in one of the definitions', async () => {
-    const deploymentManager = new DeploymentGuardPlugin({
-      processedInput: { options: { stage: 'dev' } },
-      service: {
-        custom: {
-          deployment: [{ stage: 'dev', accountId: '1234567890' }, { stage: 'dev', accountId: '0123456789' }],
-        },
-      },
-    });
+  // TODO: later
+  // it('should pass if stage and account is correct in one of the definitions', async () => {
+  //   const deploymentManager = new DeploymentGuardPlugin({
+  //     processedInput: { options: { stage: 'dev' } },
+  //     service: {
+  //       custom: {
+  //         deployment: [{ stage: 'dev', accountId: '1234567890' }, { stage: 'dev', accountId: '0123456789' }],
+  //       },
+  //     },
+  //   });
 
-    await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
-  });
+  //   await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
+  // });
 
   it('should pass if stage is correct and no account id is defined', async () => {
     const deploymentManager = new DeploymentGuardPlugin({
@@ -105,6 +119,24 @@ describe('#authorizer handler', () => {
       service: {
         custom: {
           deployment: [{ stage: 'dev', accountId: '1234567890' }],
+        },
+      },
+    });
+    await expect(deploymentManager.validateStageAndAccount()).rejects.toThrow({
+      message: "[serverless-deployment-guard] stage 'dev' cannot be deployed to account '0123456789'",
+    });
+  });
+
+  it('should throw error if trying to deploy to incorrect account', async () => {
+    const deploymentManager = new DeploymentGuardPlugin({
+      processedInput: { options: { stage: 'dev' } },
+      service: {
+        custom: {
+          deployment: [
+            { accountId: '0123456789' },
+            { stage: 'dev', accountId: '1234567890' },
+            { stage: '/ev$/i', accountId: '1234567890' },
+          ],
         },
       },
     });


### PR DESCRIPTION
This PR will allow restriction by region and without stage name.

```yaml
# serverless.yml
plugins:
  - serverless-deployment-manager
custom:
  deployment:
    - accountId: '0123456789'
```

```yaml
# serverless.yml
plugins:
  - serverless-deployment-manager
custom:
  deployment:
    - accountIds:
        - '0123456789'
        - '1234567890'
```
```yaml
# serverless.yml
plugins:
  - serverless-deployment-manager
custom:
  deployment:
    - region: 'eu-west-1'
```

```yaml
# serverless.yml
plugins:
  - serverless-deployment-manager
custom:
  deployment:
    - regions:
        - 'eu-north-1'
        - 'eu-west-1'
```
