### PR TITLE
Use before deploy hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-deployment-manager",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -32,14 +32,14 @@
       }
     },
     "@babel/core": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.0.tgz",
-      "integrity": "sha512-6Isr4X98pwXqHvtigw71CKgmhL1etZjPs5A67jL/w0TkLM9eqmFR40YrnJvEc1WnMZFsskjsmid8bHZyxKEAnw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
+      "integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.5.0",
-        "@babel/helpers": "^7.5.0",
+        "@babel/helpers": "^7.5.4",
         "@babel/parser": "^7.5.0",
         "@babel/template": "^7.4.4",
         "@babel/traverse": "^7.5.0",
@@ -276,9 +276,9 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.1.tgz",
-      "integrity": "sha512-rVOTDv8sH8kNI72Unenusxw6u+1vEepZgLxeV+jHkhsQlYhzVhzL1EpfoWT7Ub3zpWSv2WV03V853dqsnyoQzA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
+      "integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.4.4",
@@ -335,9 +335,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.1.tgz",
-      "integrity": "sha512-PVGXx5LYHcT7L4MdoE+rM5uq68IKlvU9lljVQ4OXY6aUEnGvezcGbM4VNY57Ug+3R2Zg/nYHlEdiWoIBoRA0mw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.4.tgz",
+      "integrity": "sha512-KCx0z3y7y8ipZUMAEEJOyNi11lMb/FOPUjjB113tfowgw0c16EGYos7worCKBcUAh2oG+OBnoUhsnTSoLpV9uA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -719,9 +719,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.0.tgz",
-      "integrity": "sha512-/5oQ7cYg+6sH9Dt9yx5IiylnLPiUdyMHl5y+K0mKVNiW2wJ7FpU5bg8jKcT8PcCbxdYzfv6OuC63jLEtMuRSmQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.4.tgz",
+      "integrity": "sha512-hFnFnouyRNiH1rL8YkX1ANCNAUVC8Djwdqfev8i1415tnAG+7hlA5zhZ0Q/3Q5gkop4HioIPbCEWAalqcbxRoQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -729,7 +729,7 @@
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
         "@babel/plugin-proposal-dynamic-import": "^7.5.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.5.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.4",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
@@ -1058,9 +1058,9 @@
       }
     },
     "@serverless/enterprise-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-1.1.0.tgz",
-      "integrity": "sha512-YfpQBKih5bWHrqu22UwbqoxUxdRAXwabioBl9y2QFmsG/X0dpvBED0l8ZDxCG2rUGEVUjgrN2RL3Pxzit6AV7Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-1.2.0.tgz",
+      "integrity": "sha512-C08kXRpwmYMJwBOYKdPqxF7rGGFHlSnzkBbHywTtdTOxKIS0yPgPkCQ5phsRMAIreSmgN4womPKujkZlm605kQ==",
       "dev": true,
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
@@ -1070,6 +1070,7 @@
         "fs-extra": "^7.0.1",
         "iso8601-duration": "^1.1.7",
         "isomorphic-fetch": "^2.2.1",
+        "js-yaml": "^3.13.1",
         "jsonata": "^1.6.4",
         "jszip": "^3.2.1",
         "lodash": "^4.17.11",
@@ -1078,6 +1079,8 @@
         "node-fetch": "^2.3.0",
         "regenerator-runtime": "^0.13.1",
         "semver": "^5.6.0",
+        "source-map-support": "^0.5.12",
+        "uuid": "^3.3.2",
         "yamljs": "^0.3.0"
       },
       "dependencies": {
@@ -1219,9 +1222,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.135",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.135.tgz",
-      "integrity": "sha512-Ed+tSZ9qM1oYpi5kzdsBuOzcAIn1wDW+e8TFJ50IMJMlSopGdJgKAbhHzN6h1E1OfjlGOr2JepzEWtg9NIfoNg==",
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1382,12 +1385,20 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.14",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+              "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+              "dev": true
+            }
           }
         }
       }
@@ -1556,9 +1567,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.488.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.488.0.tgz",
-      "integrity": "sha512-9AP48tyF1E5+x1CKeiRlj0Sv1YF7KI0BdSW9JP8x3ClhPWNUHjDYNH2OwsALuG1BloeY2ZigYqfI2fB7g3rNHQ==",
+      "version": "2.493.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.493.0.tgz",
+      "integrity": "sha512-xLNpjiNgLZoXqwmLQ+czP3UQzeRgsutpG1KGfVUaj/3giqEElpn0wYkwhkJt4Glm9xf3jgzAdbFEDYM7u+Llxg==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -1847,14 +1858,14 @@
       }
     },
     "browserslist": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-      "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+      "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000975",
-        "electron-to-chromium": "^1.3.164",
-        "node-releases": "^1.1.23"
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
+        "node-releases": "^1.1.25"
       }
     },
     "bser": {
@@ -1908,6 +1919,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
       "dev": true
     },
     "bytes": {
@@ -1978,9 +1995,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000980",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000980.tgz",
-      "integrity": "sha512-as0PRtWHaX3gl2gpC7qA7bX88lr+qLacMMXm1QKLLQtBCwT/Ljbgrv5EXKMNBoeEX6yFZ4vIsBb4Nh+PEwW2Rw==",
+      "version": "1.0.30000984",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz",
+      "integrity": "sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA==",
       "dev": true
     },
     "capture-exit": {
@@ -2448,6 +2465,16 @@
         "cssom": "~0.3.6"
       }
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2634,6 +2661,19 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deferred": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/deferred/-/deferred-0.7.11.tgz",
+      "integrity": "sha512-8eluCl/Blx4YOGwMapBvXRKxHXhA8ejDXYzEaK8+/gtcm8hRMhSLmXSqDmNUKNc/C8HNSmuyyp/hflhqDAvK2A==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.50",
+        "event-emitter": "^0.3.5",
+        "next-tick": "^1.0.0",
+        "timers-ext": "^0.1.7"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -2799,9 +2839,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.188",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.188.tgz",
-      "integrity": "sha512-tEQcughYIMj8WDMc59EGEtNxdGgwal/oLLTDw+NEqJRJwGflQvH3aiyiexrWeZOETP4/ko78PVr6gwNhdozvuQ==",
+      "version": "1.3.191",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz",
+      "integrity": "sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -2868,6 +2908,28 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -2881,6 +2943,41 @@
       "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -3166,6 +3263,16 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
+    "esniff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-1.1.0.tgz",
+      "integrity": "sha1-xmhJIp+RRk3t4uDUAgHtar9l8qw=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.12"
+      }
+    },
     "espree": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
@@ -3218,6 +3325,16 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "events": {
       "version": "1.1.1",
@@ -3582,6 +3699,16 @@
         "unpipe": "~1.0.0"
       }
     },
+    "find-requires": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-requires/-/find-requires-1.0.0.tgz",
+      "integrity": "sha512-UME7hNwBfzeISSFQcBEDemEEskpOjI/shPrpJM5PI4DSdn6hX0dmz+2dL70blZER2z8tSnTRL+2rfzlYgtbBoQ==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.49",
+        "esniff": "^1.1.0"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -3716,6 +3843,29 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fs2": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/fs2/-/fs2-0.3.5.tgz",
+      "integrity": "sha512-EL6G81ucjbmmycRwgekYMjjbKGFSop+eHgYLvBiQydp0H0Qugwbs5qOhifSzbCLZPy25rgXxsxsSrFqpTkitwA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "deferred": "^0.7.11",
+        "es5-ext": "^0.10.50",
+        "event-emitter": "^0.3.5",
+        "ignore": "^5.1.2",
+        "memoizee": "^0.4.14",
+        "type": "^1.0.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "dev": true
+        }
+      }
     },
     "fsevents": {
       "version": "1.2.9",
@@ -6120,6 +6270,15 @@
         "yallist": "^2.1.2"
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "lsmod": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
@@ -6200,6 +6359,22 @@
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         }
+      }
+    },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
       }
     },
     "merge-descriptors": {
@@ -6372,6 +6547,21 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncjsm": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-2.3.0.tgz",
+      "integrity": "sha512-VdfQ2cdfzPtdCeccVS1DipEvO2XiIHy61SHhFIHaHbA7KNelzlviDy5MGYANPjBHlJwHfu96DWQTS6P+rrowAA==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.1.0",
+        "deferred": "^0.7.10",
+        "es5-ext": "^0.10.49",
+        "es6-set": "^0.1.5",
+        "find-requires": "^1.0.0",
+        "fs2": "^0.3.4",
+        "type": "^1.0.1"
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -6382,6 +6572,12 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -7699,15 +7895,15 @@
       }
     },
     "serverless": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.46.1.tgz",
-      "integrity": "sha512-f5Xy6Rg9Due7OR+8dnUNkNtrueXIGDHBV5tMr+OHx/LQ2zAy0oRWGPzYUPEvEZpTu7S6Ev81U42ghU3XBkfq0Q==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.47.0.tgz",
+      "integrity": "sha512-TeRgbEw4aqF/Bi7r13HWalD6RxPK9A6Zt8WBEmVLuv9J1Yxv6ghjRo1T17r1pBAGsn89j9jk3T2h5GXd2oO3yg==",
       "dev": true,
       "requires": {
-        "@serverless/enterprise-plugin": "^1.0.7",
+        "@serverless/enterprise-plugin": "^1.2.0",
         "archiver": "^1.3.0",
         "async": "^1.5.2",
-        "aws-sdk": "^2.482.0",
+        "aws-sdk": "^2.490.0",
         "bluebird": "^3.5.5",
         "cachedir": "^2.2.0",
         "chalk": "^2.4.2",
@@ -7718,19 +7914,21 @@
         "fs-extra": "^0.26.7",
         "get-stdin": "^5.0.1",
         "globby": "^6.1.0",
-        "graceful-fs": "^4.1.15",
-        "https-proxy-agent": "^2.2.1",
+        "graceful-fs": "^4.2.0",
+        "https-proxy-agent": "^2.2.2",
+        "inquirer": "^6.4.1",
         "is-docker": "^1.1.0",
         "js-yaml": "^3.13.1",
         "json-cycle": "^1.3.0",
         "json-refs": "^2.1.7",
-        "jszip": "^3.2.1",
+        "jszip": "^3.2.2",
         "jwt-decode": "^2.2.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "moment": "^2.24.0",
         "nanomatch": "^1.2.13",
+        "ncjsm": "^2.3.0",
         "node-fetch": "^1.7.3",
         "object-hash": "^1.3.1",
         "promise-queue": "^2.2.5",
@@ -7757,6 +7955,12 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
           "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
           "dev": true
         },
         "minimist": {
@@ -8575,6 +8779,16 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -8719,6 +8933,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
       "dev": true
     },
     "type-check": {
@@ -9257,9 +9477,9 @@
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-deployment-manager",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Serverless Framework Plugin for managing deployment to predefined AWS accounts",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.488.0",
+    "aws-sdk": "^2.493.0",
     "ramda": "^0.26.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",
-    "@babel/core": "^7.5.0",
-    "@babel/preset-env": "^7.5.0 ",
+    "@babel/core": "^7.5.4",
+    "@babel/preset-env": "^7.5.4",
     "babel-jest": "^24.8.0",
     "eslint": "^6.0.1",
     "eslint-config-maasglobal": "^2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class DeploymentManagerPlugin {
     };
     this.hooks = {
       'validate:validate': this.validateStageAndAccount.bind(this),
-      'before:package:initialize': this.validateStageAndAccount.bind(this),
+      'before:deploy:deploy': this.validateStageAndAccount.bind(this),
       'before:deploy:function:initialize': this.validateStageAndAccount.bind(this),
     };
   }


### PR DESCRIPTION
This PR changes the plugin to use `before:deploy:deploy` hook instead of `before:package:initialize` so that it is possible to create a deployment package without validating the account. 