### PR TITLE
Bugfix/profile assumed role

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pre-commit": "npm run compile && npm run lint && npm run prettify",
     "prepublishOnly": "npm run compile",
     "lint": "eslint . --fix --cache",
-    "prettify": "prettier --write --ignore-path .gitignore '**/*.{css,html,js,json,md,yaml,yml}'"
+    "prettify": "prettier --write --ignore-path .gitignore \"**/*.{css,html,js,json,md,yaml,yml}\""
   },
   "author": "laardee",
   "jest": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const AWS = require('aws-sdk');
 const { filter, isNil, contains, pipe, head, reduce, sortBy, concat, not, isEmpty, findIndex } = require('ramda');
 
 function stageType(stage) {
@@ -85,8 +84,7 @@ class DeploymentManagerPlugin {
     }
 
     if (not(isEmpty(deploymentDefinition.accountIds))) {
-      const sts = new AWS.STS({ region: processedInput.options.region });
-      const { Account } = await sts.getCallerIdentity().promise();
+      const Account = await this.serverless.providers.aws.getAccountId();
       if (not(contains(Account, deploymentDefinition.accountIds))) {
         throw new Error(
           `[serverless-deployment-manager] stage '${processedInput.options.stage}' cannot be deployed to account '${Account}'`

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,37 +1,6 @@
 'use strict';
 
 const DeploymentGuardPlugin = require('../../src');
-const AWS = require('aws-sdk');
-const { forEach, keys } = require('ramda');
-
-jest.mock('aws-sdk', () => {
-  const mocks = {
-    getCallerIdentityMock: jest.fn(obj => {
-      return {
-        Account: '0123456789',
-      };
-    }),
-  };
-
-  const STS = {
-    getCallerIdentity: obj => ({
-      promise: () => mocks.getCallerIdentityMock(obj),
-    }),
-  };
-
-  return {
-    mocks,
-    STS: jest.fn().mockImplementation(() => STS),
-  };
-});
-
-afterEach(() => {
-  forEach(mock => AWS.mocks[mock].mockClear(), keys(AWS.mocks));
-});
-
-afterAll(() => {
-  jest.restoreAllMocks();
-});
 
 describe('#authorizer handler', () => {
   it('should pass if stage and account is correct', async () => {
@@ -40,6 +9,13 @@ describe('#authorizer handler', () => {
       service: {
         custom: {
           deployment: [{ stage: 'dev', accountId: '0123456789', region: 'eu-north-1' }],
+        },
+      },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
         },
       },
     });
@@ -55,6 +31,13 @@ describe('#authorizer handler', () => {
           deployment: [{ stage: '/box$/', accountId: '0123456789' }],
         },
       },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
+        },
+      },
     });
 
     await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
@@ -66,6 +49,13 @@ describe('#authorizer handler', () => {
       service: {
         custom: {
           deployment: [{ accountId: '0123456789' }],
+        },
+      },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
         },
       },
     });
@@ -109,6 +99,13 @@ describe('#authorizer handler', () => {
           deployment: [{ stage: '/box$/i', accountId: '0123456789' }],
         },
       },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
+        },
+      },
     });
 
     await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
@@ -125,6 +122,13 @@ describe('#authorizer handler', () => {
           ],
         },
       },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
+        },
+      },
     });
 
     await expect(deploymentManager.validateStageAndAccount()).resolves.toBeUndefined();
@@ -136,6 +140,13 @@ describe('#authorizer handler', () => {
       service: {
         custom: {
           deployment: [{ stage: 'dev', accountIds: ['1234567890', '0123456789'] }],
+        },
+      },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
         },
       },
     });
@@ -164,6 +175,13 @@ describe('#authorizer handler', () => {
           deployment: [{ stage: 'dev', accountId: '1234567890' }],
         },
       },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
+        },
+      },
     });
     await expect(deploymentManager.validateStageAndAccount()).rejects.toThrow({
       message: "[serverless-deployment-manager] stage 'dev' cannot be deployed to account '0123456789'",
@@ -180,6 +198,13 @@ describe('#authorizer handler', () => {
             { stage: 'dev', accountId: '1234567890' },
             { stage: '/ev$/i', accountId: '1234567890' },
           ],
+        },
+      },
+      providers: {
+        aws: {
+          getAccountId() {
+            return '0123456789';
+          },
         },
       },
     });


### PR DESCRIPTION
Fix for https://github.com/maasglobal/serverless-deployment-manager/issues/10, please have a look and publish. 

I replaced the call to AWS.STS with usage of getAccountId() from serverless library, this one gives the correct result when using profiles that assume a role in a different AWS account.

I removed the mocking from the unit tests, returning the account from the "mock" serverless object is enough (note: copy-paste was intentional, in the idea to keep tests independent of each other)